### PR TITLE
ci: fix broken `Integrate` workflow

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           cache: npm
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Build extension and tests
         run: npm run build
       - name: Run tests


### PR DESCRIPTION
This PR fixes #6.

It turns out that when installing npm dependencies with `--ignore-scripts`, playwright is not able to download the browsers needed for the tests.
