### PR TITLE
feat: add syntax highlighting

### DIFF
--- a/languages/grammars/zed.tmLanguage.json
+++ b/languages/grammars/zed.tmLanguage.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "scopeName": "source.zed",
+    "patterns": [{ "include": "#comments" }],
+    "repository": {
+        "comments": {
+            "patterns": [{ "include": "#line-comment" }]
+        },
+        "line-comment": {
+            "begin": "//",
+            "end": "$",
+            "name": "comment.line.double-dash.zed"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,13 @@
         "watch:web": "webpack watch --config webpack.web.config.ts"
     },
     "contributes": {
+        "grammars": [
+            {
+                "language": "zed",
+                "scopeName": "source.zed",
+                "path": "./languages/grammars/zed.tmLanguage.json"
+            }
+        ],
         "languages": [
             {
                 "id": "zed",


### PR DESCRIPTION
This PR registers a new TextMate language grammar for `zed` to provide syntax highlighting capability to the extension.

Closes #13 